### PR TITLE
removed forward slash in CORS origin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ logger.info("🤖 Initializing middleware");
 
 app.use(
   cors({
-    origin: "http://tulip-call4diversity-frontend.bridgeschoolapp.io/"
+    origin: "http://tulip-call4diversity-frontend.bridgeschoolapp.io"
   })
 );
 app.use(morgan("tiny", { stream: logger.stream }));


### PR DESCRIPTION
Trello Number: NA Bugfix

Task: NA

What does this code do?
removed a forward slash in the CORS allowed origin header that would not allow the deployed front end to pull from the back end!

Do I need to yarn install?
Nope!

Success criteria:
Go to http://tulip-call4diversity-frontend.bridgeschoolapp.io/ and you should see some conferences!
